### PR TITLE
Various fixes for kafka-connect-hdfs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>io.confluent</groupId>
     <artifactId>kafka-connect-hdfs</artifactId>
     <packaging>jar</packaging>
-    <version>3.1.2</version>
+    <version>3.1.2-gvs1</version>
     <name>kafka-connect-hdfs</name>
     <organization>
         <name>Confluent, Inc.</name>

--- a/pom.xml
+++ b/pom.xml
@@ -53,12 +53,13 @@
         <confluent.version>3.1.2</confluent.version>
         <kafka.version>0.10.1.1-cp1</kafka.version>
         <junit.version>4.12</junit.version>
-        <hadoop.version>2.6.1</hadoop.version>
+        <hadoop.version>2.6.4</hadoop.version>
         <hive.version>1.2.1</hive.version>
         <avro.version>1.7.7</avro.version>
         <parquet.version>1.7.0</parquet.version>
         <commons-io.version>2.4</commons-io.version>
         <joda.version>1.6.2</joda.version>
+        <slf4j.version>1.7.5</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
     </properties>
@@ -72,6 +73,11 @@
     </repositories>
 
     <dependencies>
+      <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>jul-to-slf4j</artifactId>
+          <version>${slf4j.version}</version>
+      </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>

--- a/src/main/java/io/confluent/connect/hdfs/FileUtils.java
+++ b/src/main/java/io/confluent/connect/hdfs/FileUtils.java
@@ -151,6 +151,15 @@ public class FileUtils {
     return fileStatusWithMaxOffset;
   }
 
+  public static long extractStartOffset(String filename) {
+    Matcher m = HdfsSinkConnectorConstants.COMMITTED_FILENAME_PATTERN.matcher(filename);
+    // NB: if statement has side effect of enabling group() call
+    if (!m.matches()) {
+      throw new IllegalArgumentException(filename + " does not match COMMITTED_FILENAME_PATTERN");
+    }
+    return Long.parseLong(m.group(HdfsSinkConnectorConstants.PATTERN_START_OFFSET_GROUP));
+  }
+
   public static long extractOffset(String filename) {
     Matcher m = HdfsSinkConnectorConstants.COMMITTED_FILENAME_PATTERN.matcher(filename);
     // NB: if statement has side effect of enabling group() call

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -226,6 +226,25 @@ public class HdfsSinkConnectorConfig extends AbstractConfig {
   public static final int FILENAME_OFFSET_ZERO_PAD_WIDTH_DEFAULT = 10;
   private static final String FILENAME_OFFSET_ZERO_PAD_WIDTH_DISPLAY = "Filename Offset Zero Pad Width";
 
+  public static final String APPEND_PARTITIONS_ON_COMMIT_CONFIG = "append.on.commit";
+  private static final String APPEND_PARTITIONS_ON_COMMIT_DOC =
+      "Instead of creating a new file on HDFS every time the connector flush," +
+        "append (if possible) to the older file for the same partitions instead." +
+          "NOTE: This will rename the older files to replace them with the newer ones. " +
+              "If you query this path during a commit the data might be get file not found error.";
+
+  public static final boolean APPEND_PARTITIONS_ON_COMMIT_DEFAULT = false;
+  private static final String APPEND_PARTITIONS_ON_COMMIT_DISPLAY = "Merge Contiguous Files";
+
+  public static final String MAX_TEMP_FILES_CONFIG = "max.tmp.files";
+  private static final String MAX_TEMP_FILES_DOC =
+      "Limit the number of tmp files. Once over the limit the least-recently-used " +
+          "file will be closed and reopened for append if needed later." +
+              "(Only supported by Avro for now, other format will throw an error.";
+
+  public static final int MAX_TEMP_FILES_DEFAULT = 1000;
+  private static final String MAX_TEMP_FILES_DISPLAY = "Max Temporary Files";
+
   // Schema group
   public static final String SCHEMA_COMPATIBILITY_CONFIG = "schema.compatibility";
   private static final String SCHEMA_COMPATIBILITY_DOC =
@@ -315,7 +334,12 @@ public class HdfsSinkConnectorConfig extends AbstractConfig {
         .define(LOCALE_CONFIG, Type.STRING, LOCALE_DEFAULT, Importance.MEDIUM, LOCALE_DOC, CONNECTOR_GROUP, 10, Width.MEDIUM, LOCALE_DISPLAY, partitionerClassDependentsRecommender)
         .define(TIMEZONE_CONFIG, Type.STRING, TIMEZONE_DEFAULT, Importance.MEDIUM, TIMEZONE_DOC, CONNECTOR_GROUP, 11, Width.MEDIUM, TIMEZONE_DISPLAY, partitionerClassDependentsRecommender)
         .define(FILENAME_OFFSET_ZERO_PAD_WIDTH_CONFIG, Type.INT, FILENAME_OFFSET_ZERO_PAD_WIDTH_DEFAULT, ConfigDef.Range.atLeast(0), Importance.LOW, FILENAME_OFFSET_ZERO_PAD_WIDTH_DOC,
-                CONNECTOR_GROUP, 12, Width.SHORT, FILENAME_OFFSET_ZERO_PAD_WIDTH_DISPLAY);
+                CONNECTOR_GROUP, 12, Width.SHORT, FILENAME_OFFSET_ZERO_PAD_WIDTH_DISPLAY)
+        .define(APPEND_PARTITIONS_ON_COMMIT_CONFIG, Type.BOOLEAN, APPEND_PARTITIONS_ON_COMMIT_DEFAULT, Importance.LOW, APPEND_PARTITIONS_ON_COMMIT_DOC,
+                CONNECTOR_GROUP, 13, Width.SHORT, APPEND_PARTITIONS_ON_COMMIT_DISPLAY)
+        .define(MAX_TEMP_FILES_CONFIG, Type.INT, MAX_TEMP_FILES_DEFAULT, ConfigDef.Range.atLeast(0), Importance.LOW, MAX_TEMP_FILES_DOC,
+                CONNECTOR_GROUP, 14, Width.SHORT, MAX_TEMP_FILES_DISPLAY);
+
 
     // Define Internal configuration group
     config.define(STORAGE_CLASS_CONFIG, Type.STRING, STORAGE_CLASS_DEFAULT, Importance.LOW, STORAGE_CLASS_DOC, INTERNAL_GROUP, 1, Width.MEDIUM, STORAGE_CLASS_DISPLAY);

--- a/src/main/java/io/confluent/connect/hdfs/RecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/RecordWriterProvider.java
@@ -23,5 +23,13 @@ import io.confluent.connect.avro.AvroData;
 
 public interface RecordWriterProvider {
   String getExtension();
+
+  /**
+   * Return whatever this provider support being reopened (same file, for appends)
+   */
+  boolean supportAppends();
+
+  void appendToFile(String tempFile, String previousCommitFile) throws IOException, UnsupportedOperationException;
+
   RecordWriter<SinkRecord> getRecordWriter(Configuration conf, String fileName, SinkRecord record, AvroData avroData) throws IOException;
 }

--- a/src/main/java/io/confluent/connect/hdfs/TempFileLimiter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TempFileLimiter.java
@@ -32,4 +32,7 @@ public class TempFileLimiter {
     return tempFileCount.get() >= maxOpenTempFiles;
   }
 
+  public int getMaxOpenTempFiles() {
+    return maxOpenTempFiles;
+  }
 }

--- a/src/main/java/io/confluent/connect/hdfs/TempFileLimiter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TempFileLimiter.java
@@ -1,0 +1,35 @@
+package io.confluent.connect.hdfs;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TempFileLimiter {
+
+  private int maxOpenTempFiles;
+  private final AtomicInteger tempFileCount = new AtomicInteger(0);
+
+  public TempFileLimiter(HdfsSinkConnectorConfig connectorConfig) {
+    this.maxOpenTempFiles = connectorConfig.getInt(HdfsSinkConnectorConfig.MAX_TEMP_FILES_CONFIG);
+  }
+
+  public void increment() {
+    tempFileCount.incrementAndGet();
+  }
+
+  public void decrement() {
+    tempFileCount.decrementAndGet();
+  }
+
+
+  public int get() {
+    return tempFileCount.get();
+  }
+
+  public int removeMany(int delta) {
+    return tempFileCount.addAndGet(-1 * delta);
+  }
+
+  public boolean isBusted() {
+    return tempFileCount.get() >= maxOpenTempFiles;
+  }
+
+}

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -613,6 +613,10 @@ public class TopicPartitionWriter {
 
   private void commitFile() throws IOException {
     appended.clear();
+
+    offset = offset + recordCounter;
+    recordCounter = 0;
+
     for (String encodedPartition: tempFiles.keySet()) {
       commitFile(encodedPartition);
     }
@@ -636,8 +640,7 @@ public class TopicPartitionWriter {
     }
     storage.commit(tempFile, committedFile);
     startOffsets.remove(encodedPartiton);
-    offset = offset + recordCounter;
-    recordCounter = 0;
+
     log.info("Committed {} for {}", committedFile, tp);
   }
 

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -61,6 +61,7 @@ import io.confluent.connect.hdfs.wal.WAL;
 public class TopicPartitionWriter {
   private static final Logger log = LoggerFactory.getLogger(TopicPartitionWriter.class);
 
+  // TODO: Add a global connector config
   private static final int MAX_OPEN_TEMP_FILES = 2000;
 
   private static final AtomicInteger tempFileCount = new AtomicInteger(0);
@@ -109,10 +110,9 @@ public class TopicPartitionWriter {
   private Queue<Future<Void>> hiveUpdateFutures;
   private Set<String> hivePartitions;
 
-  private boolean appendOnCommit = true;
+  private boolean appendOnCommit;
 
   private Map<String, String> previousCommitFiles = null;
-
 
   public TopicPartitionWriter(
       TopicPartition tp,
@@ -156,6 +156,7 @@ public class TopicPartitionWriter {
     timeoutMs = connectorConfig.getLong(HdfsSinkConnectorConfig.RETRY_BACKOFF_CONFIG);
     compatibility = SchemaUtils.getCompatibility(
         connectorConfig.getString(HdfsSinkConnectorConfig.SCHEMA_COMPATIBILITY_CONFIG));
+    appendOnCommit = connectorConfig.getBoolean(HdfsSinkConnectorConfig.APPEND_PARTITIONS_ON_COMMIT_CONFIG);
 
     String logsDir = connectorConfig.getString(HdfsSinkConnectorConfig.LOGS_DIR_CONFIG);
     wal = storage.wal(logsDir, tp);

--- a/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
+++ b/src/main/java/io/confluent/connect/hdfs/TopicPartitionWriter.java
@@ -149,8 +149,10 @@ public class TopicPartitionWriter {
         connectorConfig.getString(HdfsSinkConnectorConfig.SCHEMA_COMPATIBILITY_CONFIG));
     appendOnCommit = connectorConfig.getBoolean(HdfsSinkConnectorConfig.APPEND_PARTITIONS_ON_COMMIT_CONFIG);
 
-    if (appendOnCommit && !writerProvider.supportAppends())
-      throw new ConnectException(String.format("%s is on, but a writerProvider (%s) that doesn't support appends, is being used", HdfsSinkConnectorConfig.APPEND_PARTITIONS_ON_COMMIT_CONFIG, writerProvider.getClass().getName()));
+    if (appendOnCommit && !writerProvider.supportAppends()) {
+      log.error(String.format("%s is on, but a writerProvider (%s) that doesn't support appends is being used, disabling.", HdfsSinkConnectorConfig.APPEND_PARTITIONS_ON_COMMIT_CONFIG, writerProvider.getClass().getName()));
+      appendOnCommit = false;
+    }
 
     String logsDir = connectorConfig.getString(HdfsSinkConnectorConfig.LOGS_DIR_CONFIG);
     wal = storage.wal(logsDir, tp);

--- a/src/main/java/io/confluent/connect/hdfs/avro/AvroRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/avro/AvroRecordWriterProvider.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.hdfs.avro;
 
+import org.apache.avro.file.CodecFactory;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.file.SeekableInput;
 import org.apache.avro.generic.GenericDatumWriter;
@@ -51,6 +52,7 @@ public class AvroRecordWriterProvider implements RecordWriterProvider {
       throws IOException {
     DatumWriter<Object> datumWriter = new GenericDatumWriter<>();
     final DataFileWriter<Object> writer = new DataFileWriter<>(datumWriter);
+    writer.setCodec(CodecFactory.snappyCodec());
     Path path = new Path(fileName);
 
     final Schema schema = record.valueSchema();

--- a/src/main/java/io/confluent/connect/hdfs/parquet/ParquetRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/parquet/ParquetRecordWriterProvider.java
@@ -28,6 +28,8 @@ import io.confluent.connect.avro.AvroData;
 import io.confluent.connect.hdfs.RecordWriterProvider;
 import io.confluent.connect.hdfs.RecordWriter;
 
+import org.slf4j.bridge.SLF4JBridgeHandler;
+
 public class ParquetRecordWriterProvider implements RecordWriterProvider {
 
   private final static String EXTENSION = ".parquet";
@@ -41,6 +43,11 @@ public class ParquetRecordWriterProvider implements RecordWriterProvider {
   public RecordWriter<SinkRecord> getRecordWriter(
       Configuration conf, final String fileName, SinkRecord record, final AvroData avroData)
       throws IOException {
+
+    java.util.logging.LogManager.getLogManager().reset();
+    SLF4JBridgeHandler.removeHandlersForRootLogger();
+    SLF4JBridgeHandler.install();
+
     final Schema avroSchema = avroData.fromConnectSchema(record.valueSchema());
     CompressionCodecName compressionCodecName = CompressionCodecName.SNAPPY;
 

--- a/src/main/java/io/confluent/connect/hdfs/parquet/ParquetRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/parquet/ParquetRecordWriterProvider.java
@@ -40,6 +40,16 @@ public class ParquetRecordWriterProvider implements RecordWriterProvider {
   }
 
   @Override
+  public boolean supportAppends() {
+    return false;
+  }
+
+  @Override
+  public void appendToFile(String tempFile, String previousCommitFile) throws IOException, UnsupportedOperationException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public RecordWriter<SinkRecord> getRecordWriter(
       Configuration conf, final String fileName, SinkRecord record, final AvroData avroData)
       throws IOException {

--- a/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
@@ -43,6 +43,8 @@ public class FSWAL implements WAL {
   private Configuration conf = null;
   private Storage storage = null;
 
+  private boolean appendOnCommit = true;
+
   public FSWAL(String logsDir, TopicPartition topicPart, Storage storage)
       throws ConnectException {
     this.storage = storage;
@@ -119,7 +121,11 @@ public class FSWAL implements WAL {
             String tempFile = entry.getKey().getName();
             String committedFile = entry.getValue().getName();
             if (!storage.exists(committedFile)) {
-              storage.commit(tempFile, committedFile);
+              if (!appendOnCommit)
+                storage.commit(tempFile, committedFile);
+              else
+                // There is a possibility of partial writes, so delete the file, and reprocess offsets
+                storage.delete(committedFile);
             }
           }
         } else {

--- a/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
+++ b/src/main/java/io/confluent/connect/hdfs/wal/FSWAL.java
@@ -77,6 +77,7 @@ public class FSWAL implements WAL {
         break;
       } catch (RemoteException e) {
         if (e.getClassName().equals(leaseException)) {
+          log.debug(e.toString());
           log.info("Cannot acquire lease on WAL {}", logFile);
           try {
             Thread.sleep(sleepIntervalMs);

--- a/src/test/java/io/confluent/connect/hdfs/avro/TopicPartitionWriterTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/TopicPartitionWriterTest.java
@@ -14,6 +14,7 @@
 
 package io.confluent.connect.hdfs.avro;
 
+import io.confluent.connect.hdfs.*;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.kafka.connect.data.Schema;
@@ -32,13 +33,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import io.confluent.connect.hdfs.FileUtils;
-import io.confluent.connect.hdfs.Format;
-import io.confluent.connect.hdfs.HdfsSinkConnectorConfig;
-import io.confluent.connect.hdfs.RecordWriterProvider;
-import io.confluent.connect.hdfs.SchemaFileReader;
-import io.confluent.connect.hdfs.TestWithMiniDFSCluster;
-import io.confluent.connect.hdfs.TopicPartitionWriter;
 import io.confluent.connect.hdfs.filter.CommittedFileFilter;
 import io.confluent.connect.hdfs.partitioner.DefaultPartitioner;
 import io.confluent.connect.hdfs.partitioner.FieldPartitioner;
@@ -84,7 +78,7 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
     connectorProps.put(HdfsSinkConnectorConfig.FILENAME_OFFSET_ZERO_PAD_WIDTH_CONFIG, "2");
     configureConnector();
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, avroData);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, avroData, new TempFileLimiter(connectorConfig));
 
     String key = "key";
     Schema schema = createSchema();
@@ -120,7 +114,7 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
     String partitionField = (String) config.get(HdfsSinkConnectorConfig.PARTITION_FIELD_NAME_CONFIG);
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, avroData);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, avroData, new TempFileLimiter(connectorConfig));
 
     String key = "key";
     Schema schema = createSchema();
@@ -156,7 +150,7 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
     partitioner.configure(config);
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, avroData);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, avroData, new TempFileLimiter(connectorConfig));
 
     String key = "key";
     Schema schema = createSchema();

--- a/src/test/java/io/confluent/connect/hdfs/utils/MemoryRecordWriterProvider.java
+++ b/src/test/java/io/confluent/connect/hdfs/utils/MemoryRecordWriterProvider.java
@@ -36,6 +36,16 @@ public class MemoryRecordWriterProvider implements RecordWriterProvider {
   }
 
   @Override
+  public boolean supportAppends() {
+    return false;
+  }
+
+  @Override
+  public void appendToFile(String tempFile, String previousCommitFile) throws IOException, UnsupportedOperationException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public RecordWriter<SinkRecord> getRecordWriter(
       Configuration conf, final String fileName, SinkRecord record, final AvroData avroData)
       throws IOException {
@@ -48,6 +58,4 @@ public class MemoryRecordWriterProvider implements RecordWriterProvider {
 
     return new MemoryRecordWriter(fileName);
   }
-
-
 }


### PR DESCRIPTION
* Cap the temp file count + reopen in TopicPartitionWriter. Avoid the 30k files + OOM bug, with one of our use case and custom partitioning.
* Optional file merging in TopicPartitionWriter (Only supported by Avro).
* Default compression for Avro.
* Minor other fixes.