### PR TITLE
Limit max temp files + Append On Commit + Cleanup

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -45,7 +45,7 @@
     <suppress
             checks="ParameterNumber"
             files="(TopicPartitionWriter).java"
-            lines="112,148"
+            lines="155,172"
     />
 
     <suppress
@@ -62,6 +62,21 @@
     <suppress
             checks="ClassDataAbstractionCoupling"
             files="(HdfsSinkConnectorConfig).java"
+    />
+
+    <suppress
+            checks="ClassDataAbstractionCoupling"
+            files="(TopicPartitionWriter).java"
+    />
+
+    <suppress
+            checks="MethodLength"
+            files="(HdfsSinkConnectorConfig).java"
+    />
+
+    <suppress
+            checks="JavadocParagraph"
+            files=".java"
     />
 
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,14 @@
         </repository>
     </repositories>
 
+    <pluginRepositories>
+        <pluginRepository>
+            <id>confluent</id>
+            <name>Confluent</name>
+            <url>${confluent.maven.repo}</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -139,6 +147,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <compilerArguments>
                         <Xlint:all/>
                         <!-- bootstrap class path not set in conjunction with -source 1.7 -->

--- a/src/main/java/io/confluent/connect/hdfs/FileCommitter.java
+++ b/src/main/java/io/confluent/connect/hdfs/FileCommitter.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.connect.hdfs;
+
+public interface FileCommitter {
+  void commitFile(String tempFile, String committedFile);
+}

--- a/src/main/java/io/confluent/connect/hdfs/FileMerger.java
+++ b/src/main/java/io/confluent/connect/hdfs/FileMerger.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.connect.hdfs;
+
+import java.io.IOException;
+
+public interface FileMerger {
+
+  /**
+   * Append old + new => fileToMergeTo
+   *
+   * Requirements to follow in implementation:
+   *
+   * - Must overwrite fileToMergeTo (can be a partial write from previous failure)
+   * - Must support "empty" new. And return old content as fileToMergeTo.
+   */
+  void append(String oldContentFile,
+              String newContentFile,
+              String fileToMergeTo) throws IOException;
+}

--- a/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/hdfs/HdfsSinkConnectorConfig.java
@@ -112,6 +112,33 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
   private static final String KERBEROS_TICKET_RENEW_PERIOD_MS_DISPLAY = "Kerberos Ticket Renew "
       + "Period (ms)";
 
+  public static final String APPEND_ON_COMMIT_CONFIG = "append.on.commit";
+  private static final String APPEND_ON_COMMIT_DOC =
+      "Instead of creating a new file on HDFS every time the connector flush,"
+         + "append (if possible) to the older file for the same partitions instead."
+            + "NOTE: This will rename the older files to replace them with the newer ones."
+               + "If you query this path during a commit you might be get a FileNotFound error.";
+  public static final boolean APPEND_ON_COMMIT_DEFAULT = false;
+  private static final String APPEND_ON_COMMIT_DISPLAY = "Merge contiguous files";
+  
+  public static final String APPEND_ON_COMMIT_BYPASS_THRESHOLD_CONFIG =
+          "append.on.commit.bypass.threshold";
+  private static final String APPEND_ON_COMMIT_BYPASS_THRESHOLD_DOC =
+      "The connector will not attempt to append commit to a previous file "
+          + "if that is bigger than this threshold.";
+  public static final long APPEND_ON_COMMIT_BYPASS_THRESHOLD_DEFAULT = 32L * 1024L * 1024L; // 32MB;
+  private static final String APPEND_ON_COMMIT_BYPASS_THRESHOLD_DISPLAY =
+      "The maximum filesize for append commit.";
+
+  public static final String TARGET_TEMP_FILES_CONFIG = "target.tmp.files";
+  private static final String TARGET_TEMP_FILES_DOC =
+      "Try to limit the number of temporary files the connector use at once. "
+          + "This is a best-effort, there is some rules to follow that could prevent the "
+             + "exact limit to be reached but it will try to converge to this number.";
+
+  public static final int TARGET_TEMP_FILES_DEFAULT = 256;
+  private static final String TARGET_TEMP_FILES_DISPLAY = "Target maximum temporary files count";
+
   private static final ConfigDef.Recommender hdfsAuthenticationKerberosDependentsRecommender =
       new BooleanParentRecommender(
           HDFS_AUTHENTICATION_KERBEROS_CONFIG);
@@ -196,6 +223,42 @@ public class HdfsSinkConnectorConfig extends StorageSinkConnectorConfig {
           Width.SHORT,
           LOGS_DIR_DISPLAY
       );
+
+      configDef.define(
+          APPEND_ON_COMMIT_CONFIG,
+          Type.BOOLEAN,
+          APPEND_ON_COMMIT_DEFAULT,
+          Importance.LOW,
+          APPEND_ON_COMMIT_DOC,
+          group,
+          ++orderInGroup,
+          Width.SHORT,
+          APPEND_ON_COMMIT_DISPLAY
+      );
+
+      configDef.define(
+          APPEND_ON_COMMIT_BYPASS_THRESHOLD_CONFIG,
+          Type.LONG,
+          APPEND_ON_COMMIT_BYPASS_THRESHOLD_DEFAULT,
+          Importance.LOW,
+          APPEND_ON_COMMIT_BYPASS_THRESHOLD_DOC,
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          APPEND_ON_COMMIT_BYPASS_THRESHOLD_DISPLAY
+      );
+
+      configDef.define(
+          TARGET_TEMP_FILES_CONFIG,
+          Type.INT,
+              TARGET_TEMP_FILES_DEFAULT,
+          ConfigDef.Range.atLeast(0),
+          Importance.LOW,
+          TARGET_TEMP_FILES_DOC,
+            group,
+          ++orderInGroup,
+          Width.MEDIUM,
+              TARGET_TEMP_FILES_DISPLAY);
     }
 
     {

--- a/src/main/java/io/confluent/connect/hdfs/avro/AvroFileAppender.java
+++ b/src/main/java/io/confluent/connect/hdfs/avro/AvroFileAppender.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.connect.hdfs.avro;
+
+import io.confluent.connect.hdfs.FileMerger;
+import io.confluent.connect.hdfs.storage.HdfsStorage;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.mapred.FsInput;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+
+public class AvroFileAppender implements FileMerger {
+
+  private final Configuration conf;
+  private final HdfsStorage storage;
+
+  // TODO: Change HdfsStorage to Storage, once the "copy" method is available
+  public AvroFileAppender(Configuration conf, HdfsStorage storage) {
+    this.conf = conf;
+    this.storage = storage;
+  }
+
+  @Override
+  public void append(String oldContentFile,
+                     String newContentFile,
+                     String fileToMergeTo) throws IOException {
+
+    storage.copy(oldContentFile, fileToMergeTo, true);
+
+    final Path newContentFilePath = new Path(newContentFile);
+    final Path fileToMergeToPath = new Path(fileToMergeTo);
+
+    final DatumWriter<Object> datumWriter = new GenericDatumWriter<>();
+    final DataFileWriter<Object> writer = new DataFileWriter<>(datumWriter);
+
+    final DatumReader<Object> datumReader = new GenericDatumReader<>();
+
+    final FsInput inNew = new FsInput(newContentFilePath, conf);
+    final FsInput inFileToMerge = new FsInput(fileToMergeToPath, conf);
+
+    final DataFileReader<Object> reader = new DataFileReader<>(inNew, datumReader);
+
+    final FSDataOutputStream out = fileToMergeToPath.getFileSystem(conf).append(fileToMergeToPath);
+
+    writer.appendTo(inFileToMerge, out);
+
+    writer.appendAllFrom(reader, false);
+
+    writer.close();
+  }
+}

--- a/src/main/java/io/confluent/connect/hdfs/avro/AvroRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/avro/AvroRecordWriterProvider.java
@@ -14,6 +14,7 @@
 
 package io.confluent.connect.hdfs.avro;
 
+import org.apache.avro.file.CodecFactory;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -55,6 +56,10 @@ public class AvroRecordWriterProvider
       final DataFileWriter<Object> writer = new DataFileWriter<>(new GenericDatumWriter<>());
       final Path path = new Path(filename);
       Schema schema = null;
+
+      {
+        writer.setCodec(CodecFactory.snappyCodec());
+      }
 
       @Override
       public void write(SinkRecord record) {

--- a/src/test/java/io/confluent/connect/hdfs/FailureRecoveryTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/FailureRecoveryTest.java
@@ -30,7 +30,6 @@ import io.confluent.connect.hdfs.utils.MemoryFormat;
 import io.confluent.connect.hdfs.utils.MemoryRecordWriter;
 import io.confluent.connect.hdfs.utils.MemoryStorage;
 import io.confluent.connect.storage.common.StorageCommonConfig;
-import io.confluent.connect.storage.format.*;
 
 import static org.junit.Assert.assertEquals;
 
@@ -130,7 +129,7 @@ public class FailureRecoveryTest extends HdfsSinkConnectorTestBase {
     for (int i = 1; i < validOffsets.length; i++) {
       long startOffset = validOffsets[i - 1] + 1;
       long endOffset = validOffsets[i];
-      String path = FileUtils.committedFileName(url, topicsDir, directory2, TOPIC_PARTITION2,
+      String path = FileUtils.committedFileNameWithPath(url, topicsDir, directory2, TOPIC_PARTITION2,
                                                 startOffset, endOffset, extension, ZERO_PAD_FMT);
       long size = endOffset - startOffset + 1;
       List<Object> records = data.get(path);

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkTaskTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkTaskTest.java
@@ -30,7 +30,6 @@ import java.util.Map;
 
 import io.confluent.connect.avro.AvroData;
 import io.confluent.connect.hdfs.avro.AvroDataFileReader;
-import io.confluent.connect.hdfs.avro.AvroFileReader;
 import io.confluent.connect.hdfs.storage.HdfsStorage;
 import io.confluent.connect.storage.StorageFactory;
 import io.confluent.connect.storage.common.StorageCommonConfig;
@@ -102,16 +101,16 @@ public class HdfsSinkTaskTest extends TestWithMiniDFSCluster {
 
     Map<TopicPartition, List<String>> committedFiles = new HashMap<>();
     List<String> list3 = new ArrayList<>();
-    list3.add(FileUtils.committedFileName(url, topicsDir, DIRECTORY1, TOPIC_PARTITION, 100, 200,
+    list3.add(FileUtils.committedFileNameWithPath(url, topicsDir, DIRECTORY1, TOPIC_PARTITION, 100, 200,
                                           extension, ZERO_PAD_FMT));
-    list3.add(FileUtils.committedFileName(url, topicsDir, DIRECTORY1, TOPIC_PARTITION, 201, 300,
+    list3.add(FileUtils.committedFileNameWithPath(url, topicsDir, DIRECTORY1, TOPIC_PARTITION, 201, 300,
                                           extension, ZERO_PAD_FMT));
     committedFiles.put(TOPIC_PARTITION, list3);
 
     List<String> list4 = new ArrayList<>();
-    list4.add(FileUtils.committedFileName(url, topicsDir, DIRECTORY2, TOPIC_PARTITION2, 400, 500,
+    list4.add(FileUtils.committedFileNameWithPath(url, topicsDir, DIRECTORY2, TOPIC_PARTITION2, 400, 500,
                                           extension, ZERO_PAD_FMT));
-    list4.add(FileUtils.committedFileName(url, topicsDir, DIRECTORY2, TOPIC_PARTITION2, 501, 800,
+    list4.add(FileUtils.committedFileNameWithPath(url, topicsDir, DIRECTORY2, TOPIC_PARTITION2, 501, 800,
                                           extension, ZERO_PAD_FMT));
     committedFiles.put(TOPIC_PARTITION2, list4);
 
@@ -167,7 +166,7 @@ public class HdfsSinkTaskTest extends TestWithMiniDFSCluster {
       for (int j = 1; j < validOffsets.length; ++j) {
         long startOffset = validOffsets[j - 1] + 1;
         long endOffset = validOffsets[j];
-        Path path = new Path(FileUtils.committedFileName(url, topicsDir, directory, tp,
+        Path path = new Path(FileUtils.committedFileNameWithPath(url, topicsDir, directory, tp,
                                                          startOffset, endOffset, extension,
                                                          ZERO_PAD_FMT));
         Collection<Object> records = schemaFileReader.readData(connectorConfig.getHadoopConfiguration(), path);
@@ -209,7 +208,7 @@ public class HdfsSinkTaskTest extends TestWithMiniDFSCluster {
       for (int j = 1; j < validOffsets.length; ++j) {
         long startOffset = validOffsets[j - 1] + 1;
         long endOffset = validOffsets[j];
-        Path path = new Path(FileUtils.committedFileName(url, topicsDir, directory, tp,
+        Path path = new Path(FileUtils.committedFileNameWithPath(url, topicsDir, directory, tp,
                 startOffset, endOffset, extension,
                 ZERO_PAD_FMT));
         Collection<Object> records = schemaFileReader.readData(connectorConfig.getHadoopConfiguration(), path);
@@ -223,13 +222,13 @@ public class HdfsSinkTaskTest extends TestWithMiniDFSCluster {
   }
 
   private void createCommittedFiles() throws IOException {
-    String file1 = FileUtils.committedFileName(url, topicsDir, DIRECTORY1, TOPIC_PARTITION, 0,
+    String file1 = FileUtils.committedFileNameWithPath(url, topicsDir, DIRECTORY1, TOPIC_PARTITION, 0,
                                                10, extension, ZERO_PAD_FMT);
-    String file2 = FileUtils.committedFileName(url, topicsDir, DIRECTORY1, TOPIC_PARTITION, 11,
+    String file2 = FileUtils.committedFileNameWithPath(url, topicsDir, DIRECTORY1, TOPIC_PARTITION, 11,
                                                20, extension, ZERO_PAD_FMT);
-    String file3 = FileUtils.committedFileName(url, topicsDir, DIRECTORY1, TOPIC_PARTITION2, 21,
+    String file3 = FileUtils.committedFileNameWithPath(url, topicsDir, DIRECTORY1, TOPIC_PARTITION2, 21,
                                                40, extension, ZERO_PAD_FMT);
-    String file4 = FileUtils.committedFileName(url, topicsDir, DIRECTORY1, TOPIC_PARTITION2, 41,
+    String file4 = FileUtils.committedFileNameWithPath(url, topicsDir, DIRECTORY1, TOPIC_PARTITION2, 41,
                                                45, extension, ZERO_PAD_FMT);
     fs.createNewFile(new Path(file1));
     fs.createNewFile(new Path(file2));

--- a/src/test/java/io/confluent/connect/hdfs/HdfsSinkTaskTestWithSecureHDFS.java
+++ b/src/test/java/io/confluent/connect/hdfs/HdfsSinkTaskTestWithSecureHDFS.java
@@ -23,11 +23,9 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Map;
 
 import io.confluent.connect.avro.AvroData;
 import io.confluent.connect.hdfs.avro.AvroDataFileReader;
-import io.confluent.connect.hdfs.avro.AvroFileReader;
 
 import static org.junit.Assert.assertEquals;
 
@@ -68,7 +66,7 @@ public class HdfsSinkTaskTestWithSecureHDFS extends TestWithSecureMiniDFSCluster
       for (int j = 1; j < validOffsets.length; ++j) {
         long startOffset = validOffsets[j - 1] + 1;
         long endOffset = validOffsets[j];
-        Path path = new Path(FileUtils.committedFileName(url, topicsDir, directory, tp,
+        Path path = new Path(FileUtils.committedFileNameWithPath(url, topicsDir, directory, tp,
                                                          startOffset, endOffset, extension,
                                                          ZERO_PAD_FMT));
         Collection<Object> records = schemaFileReader.readData(connectorConfig.getHadoopConfiguration(), path);

--- a/src/test/java/io/confluent/connect/hdfs/TestWithMiniDFSCluster.java
+++ b/src/test/java/io/confluent/connect/hdfs/TestWithMiniDFSCluster.java
@@ -293,7 +293,7 @@ public class TestWithMiniDFSCluster extends HdfsSinkConnectorTestBase {
         long startOffset = validOffsets[i - 1];
         long endOffset = validOffsets[i] - 1;
 
-        String filename = FileUtils.committedFileName(url, topicsDir, getDirectory(tp.topic(), tp.partition()), tp,
+        String filename = FileUtils.committedFileNameWithPath(url, topicsDir, getDirectory(tp.topic(), tp.partition()), tp,
                                                       startOffset, endOffset, extension, zeroPadFormat);
         Path path = new Path(filename);
         Collection<Object> records = dataFileReader.readData(connectorConfig.getHadoopConfiguration(), path);
@@ -311,7 +311,7 @@ public class TestWithMiniDFSCluster extends HdfsSinkConnectorTestBase {
     for (int i = 1; i < validOffsets.length; ++i) {
       long startOffset = validOffsets[i - 1];
       long endOffset = validOffsets[i] - 1;
-      expectedFiles.add(FileUtils.committedFileName(url, topicsDir, getDirectory(tp.topic(), tp.partition()), tp,
+      expectedFiles.add(FileUtils.committedFileNameWithPath(url, topicsDir, getDirectory(tp.topic(), tp.partition()), tp,
                                                     startOffset, endOffset, extension, zeroPadFormat));
     }
     return expectedFiles;

--- a/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/DataWriterAvroTest.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import io.confluent.common.utils.MockTime;
 import io.confluent.common.utils.Time;
 import io.confluent.connect.hdfs.DataWriter;
 import io.confluent.connect.hdfs.FileUtils;
@@ -88,7 +87,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
       long endOffset = (i + 1) * 10 - 1;
       String tempfile = FileUtils.tempFileName(url, topicsDir, getDirectory(), extension);
       fs.createNewFile(new Path(tempfile));
-      String committedFile = FileUtils.committedFileName(url, topicsDir, getDirectory(), TOPIC_PARTITION, startOffset,
+      String committedFile = FileUtils.committedFileNameWithPath(url, topicsDir, getDirectory(), TOPIC_PARTITION, startOffset,
                                                          endOffset, extension, zeroPadFormat);
       wal.append(tempfile, committedFile);
     }
@@ -173,7 +172,7 @@ public class DataWriterAvroTest extends TestWithMiniDFSCluster {
     long[] endOffsets = {2, 5};
 
     for (int i = 0; i < startOffsets.length; ++i) {
-      Path path = new Path(FileUtils.committedFileName(url, topicsDir, directory, TOPIC_PARTITION, startOffsets[i],
+      Path path = new Path(FileUtils.committedFileNameWithPath(url, topicsDir, directory, TOPIC_PARTITION, startOffsets[i],
                                                        endOffsets[i], extension, zeroPadFormat));
       fs.createNewFile(path);
     }

--- a/src/test/java/io/confluent/connect/hdfs/avro/TopicPartitionWriterTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/avro/TopicPartitionWriterTest.java
@@ -195,9 +195,9 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
     String directory3 = partitioner.generatePartitionedPath(TOPIC, partitionField + "=" + String.valueOf(18));
 
     Set<Path> expectedFiles = new HashSet<>();
-    expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, directory1, TOPIC_PARTITION, 0, 2, extension, zeroPadFormat)));
-    expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, directory2, TOPIC_PARTITION, 3, 5, extension, zeroPadFormat)));
-    expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, directory3, TOPIC_PARTITION, 6, 8, extension, zeroPadFormat)));
+    expectedFiles.add(new Path(FileUtils.committedFileNameWithPath(url, topicsDir, directory1, TOPIC_PARTITION, 0, 2, extension, zeroPadFormat)));
+    expectedFiles.add(new Path(FileUtils.committedFileNameWithPath(url, topicsDir, directory2, TOPIC_PARTITION, 3, 5, extension, zeroPadFormat)));
+    expectedFiles.add(new Path(FileUtils.committedFileNameWithPath(url, topicsDir, directory3, TOPIC_PARTITION, 6, 8, extension, zeroPadFormat)));
 
     int expectedBatchSize = 3;
     verify(expectedFiles, expectedBatchSize, records, schema);
@@ -247,9 +247,9 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
     String directory = partitioner.generatePartitionedPath(TOPIC, encodedPartition);
 
     Set<Path> expectedFiles = new HashSet<>();
-    expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, directory, TOPIC_PARTITION, 0, 2, extension, zeroPadFormat)));
-    expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, directory, TOPIC_PARTITION, 3, 5, extension, zeroPadFormat)));
-    expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, directory, TOPIC_PARTITION, 6, 8, extension, zeroPadFormat)));
+    expectedFiles.add(new Path(FileUtils.committedFileNameWithPath(url, topicsDir, directory, TOPIC_PARTITION, 0, 2, extension, zeroPadFormat)));
+    expectedFiles.add(new Path(FileUtils.committedFileNameWithPath(url, topicsDir, directory, TOPIC_PARTITION, 3, 5, extension, zeroPadFormat)));
+    expectedFiles.add(new Path(FileUtils.committedFileNameWithPath(url, topicsDir, directory, TOPIC_PARTITION, 6, 8, extension, zeroPadFormat)));
 
     int expectedBatchSize = 3;
     verify(expectedFiles, expectedBatchSize, records, schema);
@@ -333,12 +333,12 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
     String dirPrefixFirst = partitioner.generatePartitionedPath(TOPIC, encodedPartitionFirst);
     Set<Path> expectedFiles = new HashSet<>();
     for (int i : new int[]{0, 3, 6}) {
-      expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, dirPrefixFirst, TOPIC_PARTITION, i, i + 2, extension, zeroPadFormat)));
+      expectedFiles.add(new Path(FileUtils.committedFileNameWithPath(url, topicsDir, dirPrefixFirst, TOPIC_PARTITION, i, i + 2, extension, zeroPadFormat)));
     }
 
     String dirPrefixLater = partitioner.generatePartitionedPath(TOPIC, encodedPartitionLater);
     for (int i : new int[]{9, 12, 15}) {
-      expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, dirPrefixLater, TOPIC_PARTITION, i, i + 2, extension, zeroPadFormat)));
+      expectedFiles.add(new Path(FileUtils.committedFileNameWithPath(url, topicsDir, dirPrefixLater, TOPIC_PARTITION, i, i + 2, extension, zeroPadFormat)));
     }
     verify(expectedFiles, 3, records, schema);
   }
@@ -394,13 +394,13 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
     String dirPrefixFirst = partitioner.generatePartitionedPath(TOPIC, encodedPartitionFirst);
     Set<Path> expectedFiles = new HashSet<>();
     for (int i : new int[]{0, 3, 6}) {
-      expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, dirPrefixFirst, TOPIC_PARTITION, i, i + 2, extension, zeroPadFormat)));
+      expectedFiles.add(new Path(FileUtils.committedFileNameWithPath(url, topicsDir, dirPrefixFirst, TOPIC_PARTITION, i, i + 2, extension, zeroPadFormat)));
     }
 
     String dirPrefixLater = partitioner.generatePartitionedPath(TOPIC, encodedPartitionLater);
     // Records 15,16,17 won't be flushed until a record with a higher timestamp arrives.
     for (int i : new int[]{9, 12}) {
-      expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, dirPrefixLater, TOPIC_PARTITION, i, i + 2, extension, zeroPadFormat)));
+      expectedFiles.add(new Path(FileUtils.committedFileNameWithPath(url, topicsDir, dirPrefixLater, TOPIC_PARTITION, i, i + 2, extension, zeroPadFormat)));
     }
     verify(expectedFiles, 3, records, schema);
   }
@@ -457,13 +457,13 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
     String dirPrefixFirst = partitioner.generatePartitionedPath(TOPIC, encodedPartitionFirst);
     Set<Path> expectedFiles = new HashSet<>();
     for (int i : new int[]{0, 3, 6}) {
-      expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, dirPrefixFirst, TOPIC_PARTITION, i, i + 2, extension, zeroPadFormat)));
+      expectedFiles.add(new Path(FileUtils.committedFileNameWithPath(url, topicsDir, dirPrefixFirst, TOPIC_PARTITION, i, i + 2, extension, zeroPadFormat)));
     }
 
     String dirPrefixLater = partitioner.generatePartitionedPath(TOPIC, encodedPartitionLater);
     // Records 15,16,17 won't be flushed until a record with a higher timestamp arrives.
     for (int i : new int[]{9, 12}) {
-      expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, dirPrefixLater, TOPIC_PARTITION, i, i + 2, extension, zeroPadFormat)));
+      expectedFiles.add(new Path(FileUtils.committedFileNameWithPath(url, topicsDir, dirPrefixLater, TOPIC_PARTITION, i, i + 2, extension, zeroPadFormat)));
     }
     verify(expectedFiles, 3, records, schema);
   }
@@ -553,12 +553,12 @@ public class TopicPartitionWriterTest extends TestWithMiniDFSCluster {
     String dirPrefixFirst = partitioner.generatePartitionedPath(TOPIC, encodedPartitionFirst);
     Set<Path> expectedFiles = new HashSet<>();
     for (int i : new int[]{0}) {
-      expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, dirPrefixFirst, TOPIC_PARTITION, i, i + 2, extension, zeroPadFormat)));
+      expectedFiles.add(new Path(FileUtils.committedFileNameWithPath(url, topicsDir, dirPrefixFirst, TOPIC_PARTITION, i, i + 2, extension, zeroPadFormat)));
     }
 
     String dirPrefixLater = partitioner.generatePartitionedPath(TOPIC, encodedPartitionLater);
     for (int i : new int[]{3}) {
-      expectedFiles.add(new Path(FileUtils.committedFileName(url, topicsDir, dirPrefixLater, TOPIC_PARTITION, i, i + 2, extension, zeroPadFormat)));
+      expectedFiles.add(new Path(FileUtils.committedFileNameWithPath(url, topicsDir, dirPrefixLater, TOPIC_PARTITION, i, i + 2, extension, zeroPadFormat)));
     }
     verify(expectedFiles, 3, records, schema);
   }

--- a/src/test/java/io/confluent/connect/hdfs/wal/WALTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/wal/WALTest.java
@@ -54,7 +54,7 @@ public class WALTest extends TestWithMiniDFSCluster {
 
     String directory = TOPIC + "/" + String.valueOf(PARTITION);
     final String tempfile = FileUtils.tempFileName(url, topicsDir, directory, extension);
-    final String committedFile = FileUtils.committedFileName(
+    final String committedFile = FileUtils.committedFileNameWithPath(
         url,
         topicsDir,
         directory,


### PR DESCRIPTION
Problem:

* Depending on the number of partitions and the partitioning scheme an HdfsSinkTask could create too many temporary files,
possibly OOMing on slowing down to a stall.

Solution:

* Limiting the number of temporary files open at once by dropping record that would cause a topic-partition to
create more file than the limit per worker.
* Once the temp files for some topic-partition are closed allow new topic-partition to written.
* Randomize the order the assignments are written, to avoid some partition never being written.
* Rewind the "unwritten" topic-partition on flush (commit) to retry the dropped records.

Caveat:

* That will cause the topic-partition to re-read many time if the connector it the limit. However, it's still better to
have a limit in place than to live with the problem cited above. If it's an issue, make sure you don't hit the limit,
by tweaking the # of partitioning, order of records, or the partitioning scheme.

Problem:

* Since KafkaConnectHDFS include the offsets in the filename it won't append to an continuous data file. It will thus
probably create a lot of files.

Solution:

* Continue writing each batch to a new temporary file in between every rotation. When it's time to commit however,
append the temp file to last committed file, and rename it for it to match to right offset.
* Include the necessary gymnastic to ensure that errors during commit don't cause corruption or loss of data.
* Actually copy and then append, to prevent partial write AND to support format that don't support appending directly (Parquet).
* For Avro append directly to the copy if possible.
* For Parquet read both files and generate a new file (Using Parquet 1.9+ appendFile) (Not implemented)

Caveats:

* If you query the destination folder, you might get of errors because of "disappearing" files, since some files might
be renamed while your query run. If that's a problem, don't enable this feature or pause the connector while you need to
query the data.

* Fix some NPE
* More readable FileUtils.fileStatusWithMaxOffset
* Bump compatibility to Java 8, to allow for lambda to be used.